### PR TITLE
Add check of result.TrackMetaData content

### DIFF
--- a/lib/services/AVTransport.js
+++ b/lib/services/AVTransport.js
@@ -117,7 +117,7 @@ AVTransport.prototype.CurrentTrack = async function () {
       let duration = Helpers.TimeToSeconds(result.TrackDuration)
       let trackUri = result.TrackURI || null
       let queuePosition = parseInt(result.Track)
-      if (result.TrackMetaData) { // There is some metadata, lets parse it.
+      if (result.TrackMetaData && result.TrackMetaData != 'NOT_IMPLEMENTED') { // There is some metadata, lets parse it.
         var metadata = await Helpers.ParseXml(result.TrackMetaData)
         let track = Helpers.ParseDIDL(metadata)
         track.position = position


### PR DESCRIPTION
When queue is empty, result.TrackMetaData exists with value 'NOT_IMPLEMENTED'. ParseXML doesn't like that !!